### PR TITLE
Replace GLFW with SDL2

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,6 @@
             "mode": "debug",
             "program": "${workspaceRoot}",
             "env": {
-                // "NANA_FPS_COUNTER": "TRUE",
                 // "NANA_DEBUG": "TRUE",
                 // "NANA_LCD_STATE_DEBUG": "TRUE",
                 // "NANA_MEMORY_ACCESS_DEBUG": "TRUE",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
 FROM golang:1.10.3
 
-# hajimehoshi/ebiten dependencies: https://github.com/hajimehoshi/ebiten/wiki/Linux
+# veandco/go-sdl2: https://github.com/veandco/go-sdl2/#requirements
 RUN apt update && \
     apt install -y \
-    libglu1-mesa-dev \
-    libgles2-mesa-dev \
-    libxrandr-dev \
-    libxcursor-dev \
-    libxinerama-dev \
-    libxi-dev \
-    libasound2-dev
-
+    libsdl2-image-dev \
+    libsdl2-mixer-dev \
+    libsdl2-ttf-dev \
+    libsdl2-gfx-dev

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -36,7 +36,7 @@ type Emulator struct {
 	LeftChannelEnable  [4]bool
 	SoundEnabled       bool
 	SoundSampleCounter int
-	SoundBuffer        []int16
+	SoundBuffer        []uint8
 
 	CartridgeMemory          [0x200000]uint8
 	ROM                      [0x10000]uint8

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -58,9 +58,7 @@ type Emulator struct {
 	ScanlineRenderCyclesCounter int
 	ScreenData                  [160][144][3]uint8
 
-	JoypadState uint8
-
-	EnableFPSOverlay        bool
+	JoypadState             uint8
 	EnableDebug             bool
 	EnableLCDStateDebug     bool
 	EnableMemoryAccessDebug bool
@@ -73,9 +71,8 @@ type Emulator struct {
 	CartridgeType CartridgeType
 }
 
-func NewEmulator(enableFPSOverlay bool, enableDebug bool, enableLCDStateDebug bool, enableMemoryAccessDebug bool, enableTestPanics bool, maxCycles int) *Emulator {
+func NewEmulator(enableDebug bool, enableLCDStateDebug bool, enableMemoryAccessDebug bool, enableTestPanics bool, maxCycles int) *Emulator {
 	e := new(Emulator)
-	e.EnableFPSOverlay = enableFPSOverlay
 	if enableDebug {
 		e.SetupLogFile()
 	}

--- a/emulator/emulator_test.go
+++ b/emulator/emulator_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func BenchmarkEmulateFrame(b *testing.B) {
-	e := NewEmulator(false, false, false, false, false, 0)
+	e := NewEmulator(false, false, false, false, 0)
 	e.LoadCartridge("../tetris.gb")
 	for n := 0; n < b.N; n++ {
 		e.EmulateFrame()
@@ -23,7 +23,7 @@ var _ = Describe("Emulator", func() {
 	)
 
 	BeforeEach(func() {
-		emulator = *NewEmulator(false, false, false, false, false, 0)
+		emulator = *NewEmulator(false, false, false, false, 0)
 	})
 
 	Describe("verifying the initial values", func() {

--- a/emulator/jump_table_extended_test.go
+++ b/emulator/jump_table_extended_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Emulator", func() {
 	)
 
 	BeforeEach(func() {
-		emulator = *NewEmulator(false, false, false, false, false, 0)
+		emulator = *NewEmulator(false, false, false, false, 0)
 	})
 
 	Describe("verifying operation codes work", func() {

--- a/emulator/jump_table_test.go
+++ b/emulator/jump_table_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Emulator", func() {
 	)
 
 	BeforeEach(func() {
-		emulator = *NewEmulator(false, false, false, false, false, 0)
+		emulator = *NewEmulator(false, false, false, false, 0)
 	})
 
 	Describe("verifying operation codes work", func() {

--- a/emulator/memory_access_test.go
+++ b/emulator/memory_access_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Emulator", func() {
 	)
 
 	BeforeEach(func() {
-		emulator = *NewEmulator(false, false, false, false, false, 0)
+		emulator = *NewEmulator(false, false, false, false, 0)
 	})
 
 	Describe("verifying memory access", func() {

--- a/emulator/sound.go
+++ b/emulator/sound.go
@@ -83,7 +83,7 @@ func (e *Emulator) UpdateSound(cycles int) {
 			}
 			leftVolue := float32(e.LeftVolume) / float32(7)
 			volume = uint8(float32(volume) * leftVolue)
-			e.SoundBuffer = append(e.SoundBuffer, PCM16Bit(volume))
+			e.SoundBuffer = append(e.SoundBuffer, volume)
 
 			volume = uint8(0)
 			if e.RightChannelEnable[0] {
@@ -100,13 +100,9 @@ func (e *Emulator) UpdateSound(cycles int) {
 			}
 			rightVolume := float32(e.RightVolume) / float32(7)
 			volume = uint8(float32(volume) * rightVolume)
-			e.SoundBuffer = append(e.SoundBuffer, PCM16Bit(volume))
+			e.SoundBuffer = append(e.SoundBuffer, volume)
 		}
 	}
-}
-
-func PCM16Bit(data uint8) int16 {
-	return (int16(data) - 0x80) << 8
 }
 
 // Credits for this go to Viktor T. Toth

--- a/emulator/stack_test.go
+++ b/emulator/stack_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Emulator", func() {
 	)
 
 	BeforeEach(func() {
-		emulator = *NewEmulator(false, false, false, false, false, 0)
+		emulator = *NewEmulator(false, false, false, false, 0)
 	})
 
 	Describe("verifying push/pop 16-Bit values into stack", func() {

--- a/main.go
+++ b/main.go
@@ -167,7 +167,6 @@ func AudioCallback(userdata unsafe.Pointer, stream *C.Uint8, length C.int) {
 
 func main() {
 	gameArg := os.Args[1]
-	_, okFPSCounter := os.LookupEnv("NANA_FPS_COUNTER")
 	_, okDebug := os.LookupEnv("NANA_DEBUG")
 	_, okLCDState := os.LookupEnv("NANA_LCD_STATE_DEBUG")
 	_, okMemoryAccess := os.LookupEnv("NANA_MEMORY_ACCESS_DEBUG")
@@ -181,7 +180,7 @@ func main() {
 		}
 		maxCycles = maxCyclesInt
 	}
-	e = emulator.NewEmulator(okFPSCounter, okDebug, okLCDState, okMemoryAccess, okEnableTestPanics, maxCycles)
+	e = emulator.NewEmulator(okDebug, okLCDState, okMemoryAccess, okEnableTestPanics, maxCycles)
 	e.LoadCartridge(gameArg)
 
 	if err := sdl.Init(sdl.INIT_EVERYTHING); err != nil {

--- a/main.go
+++ b/main.go
@@ -21,6 +21,95 @@ var (
 )
 
 func update(r *sdl.Renderer, t *sdl.Texture) error {
+	for event := sdl.PollEvent(); event != nil; event = sdl.PollEvent() {
+		switch event.(type) {
+		case *sdl.KeyboardEvent:
+			event := event.(*sdl.KeyboardEvent)
+			switch event.Keysym.Sym {
+			case 'a':
+				switch event.State {
+				case sdl.PRESSED:
+					e.PressKey(4)
+					break
+				case sdl.RELEASED:
+					e.ReleaseKey(4)
+					break
+				}
+				break
+			case 's':
+				switch event.State {
+				case sdl.PRESSED:
+					e.PressKey(5)
+					break
+				case sdl.RELEASED:
+					e.ReleaseKey(5)
+					break
+				}
+				break
+			case sdl.K_UP:
+				switch event.State {
+				case sdl.PRESSED:
+					e.PressKey(2)
+					break
+				case sdl.RELEASED:
+					e.ReleaseKey(2)
+					break
+				}
+				break
+			case sdl.K_DOWN:
+				switch event.State {
+				case sdl.PRESSED:
+					e.PressKey(3)
+					break
+				case sdl.RELEASED:
+					e.ReleaseKey(3)
+					break
+				}
+				break
+			case sdl.K_LEFT:
+				switch event.State {
+				case sdl.PRESSED:
+					e.PressKey(1)
+					break
+				case sdl.RELEASED:
+					e.ReleaseKey(1)
+					break
+				}
+				break
+			case sdl.K_RIGHT:
+				switch event.State {
+				case sdl.PRESSED:
+					e.PressKey(0)
+					break
+				case sdl.RELEASED:
+					e.ReleaseKey(0)
+					break
+				}
+				break
+			case sdl.K_RETURN:
+				switch event.State {
+				case sdl.PRESSED:
+					e.PressKey(7)
+					break
+				case sdl.RELEASED:
+					e.ReleaseKey(7)
+					break
+				}
+				break
+			case sdl.K_SPACE:
+				switch event.State {
+				case sdl.PRESSED:
+					e.PressKey(6)
+					break
+				case sdl.RELEASED:
+					e.ReleaseKey(6)
+					break
+				}
+				break
+			}
+		}
+	}
+
 	e.EmulateFrame()
 
 	pixels, _, _ := t.Lock(nil)


### PR DESCRIPTION
This PR replaces GLFW ([hajimehoshi/ebiten](https://github.com/hajimehoshi/ebiten/)) with SDL2 ([veandco/go-sdl2](https://github.com/veandco/go-sdl2)).

I believe it should be possible to compile this project for ARM (using [libtransistor](https://github.com/reswitched/libtransistor) or [libnx](https://github.com/switchbrew/libnx)) and have it running on a Nintendo Switch, sadly there is no Nintendo Switch support yet in GLFW (or any port of it) but there is a lot of progress in SDL2 (see [sdl-libtransistor](https://github.com/reswitched/sdl-libtransistor) for example).

Most of the progress in the emulator stays the same, meaning the know issues are still there with SDL. The only noticeable change this PR introduces is the removal of the FPS counter support. 