### PR TITLE
Add rewinding with state buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ $ nana path/to/rom.gb
 * `NANA_LCD_STATE_DEBUG`: includes the LCD state in debug output
 * `NANA_MEMORY_ACCESS_DEBUG`: includes the LCD state in debug output
 * `NANA_ENABLE_TEST_PANICS`: panic on undefined behaviour
+* `NANA_ENABLE_REWIND`: hold F10 to rewind the emulation
 * `NANA_MAX_CYCLES`: enables automatic shut down to specific cycle threshold
 
 ### Building your own emulator

--- a/emulator/emulator_test.go
+++ b/emulator/emulator_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func BenchmarkEmulateFrame(b *testing.B) {
-	e := NewEmulator(false, false, false, false, 0)
+	e := NewEmulator(false, false, false, false, false, 0)
 	e.LoadCartridge("../tetris.gb")
 	for n := 0; n < b.N; n++ {
 		e.EmulateFrame()
@@ -23,7 +23,7 @@ var _ = Describe("Emulator", func() {
 	)
 
 	BeforeEach(func() {
-		emulator = *NewEmulator(false, false, false, false, 0)
+		emulator = *NewEmulator(false, false, false, false, false, 0)
 	})
 
 	Describe("verifying the initial values", func() {

--- a/emulator/joypad.go
+++ b/emulator/joypad.go
@@ -56,6 +56,9 @@ func (e *Emulator) HandleKeyboardEvent(keyboardEvent *sdl.KeyboardEvent) {
 	switch keyboardEvent.State {
 	case sdl.PRESSED:
 		switch keyboardEvent.Keysym.Sym {
+		case sdl.K_F10:
+			e.Rewinding = true
+			break
 		case sdl.K_F11:
 			e.SaveState()
 			break
@@ -67,8 +70,14 @@ func (e *Emulator) HandleKeyboardEvent(keyboardEvent *sdl.KeyboardEvent) {
 			break
 		}
 	case sdl.RELEASED:
-		e.ReleaseKey(e.KeyMap[keyboardEvent.Keysym.Sym])
-		break
+		switch keyboardEvent.Keysym.Sym {
+		case sdl.K_F10:
+			e.Rewinding = false
+			break
+		default:
+			e.ReleaseKey(e.KeyMap[keyboardEvent.Keysym.Sym])
+			break
+		}
 	}
 }
 

--- a/emulator/jump_table_extended_test.go
+++ b/emulator/jump_table_extended_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Emulator", func() {
 	)
 
 	BeforeEach(func() {
-		emulator = *NewEmulator(false, false, false, false, 0)
+		emulator = *NewEmulator(false, false, false, false, false, 0)
 	})
 
 	Describe("verifying operation codes work", func() {

--- a/emulator/jump_table_test.go
+++ b/emulator/jump_table_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Emulator", func() {
 	)
 
 	BeforeEach(func() {
-		emulator = *NewEmulator(false, false, false, false, 0)
+		emulator = *NewEmulator(false, false, false, false, false, 0)
 	})
 
 	Describe("verifying operation codes work", func() {

--- a/emulator/memory_access_test.go
+++ b/emulator/memory_access_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Emulator", func() {
 	)
 
 	BeforeEach(func() {
-		emulator = *NewEmulator(false, false, false, false, 0)
+		emulator = *NewEmulator(false, false, false, false, false, 0)
 	})
 
 	Describe("verifying memory access", func() {

--- a/emulator/stack_test.go
+++ b/emulator/stack_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Emulator", func() {
 	)
 
 	BeforeEach(func() {
-		emulator = *NewEmulator(false, false, false, false, 0)
+		emulator = *NewEmulator(false, false, false, false, false, 0)
 	})
 
 	Describe("verifying push/pop 16-Bit values into stack", func() {

--- a/emulator/state.go
+++ b/emulator/state.go
@@ -78,6 +78,39 @@ func NewState(e *Emulator) *State {
 	return s
 }
 
+func (e *Emulator) CopyState(s *State) {
+	e.AF = s.AF
+	e.BC = s.BC
+	e.DE = s.DE
+	e.HL = s.HL
+	e.SquareOne = s.SquareOne
+	e.SquareTwo = s.SquareTwo
+	e.Wave = s.Wave
+	e.Noise = s.Noise
+	e.RightVolume = s.RightVolume
+	e.LeftVolume = s.LeftVolume
+	e.RightChannelEnable = s.RightChannelEnable
+	e.LeftChannelEnable = s.LeftChannelEnable
+	e.SoundEnabled = s.SoundEnabled
+	e.SoundSampleCounter = s.SoundSampleCounter
+	e.SoundBuffer = s.SoundBuffer
+	e.ROM = s.ROM
+	e.RAM = s.RAM
+	e.ProgramCounter = s.ProgramCounter
+	e.StackPointer = s.StackPointer
+	e.CurrentROMBank = s.CurrentROMBank
+	e.CurrentRAMBank = s.CurrentRAMBank
+	e.EnableRAMBank = s.EnableRAMBank
+	e.EnableROMBank = s.EnableROMBank
+	e.Halted = s.Halted
+	e.DisableInterrupts = s.DisableInterrupts
+	e.PendingDisableInterrupts = s.PendingDisableInterrupts
+	e.PendingEnableInterrupts = s.PendingEnableInterrupts
+	e.DividerRegisterCyclesCounter = s.DividerRegisterCyclesCounter
+	e.TimerCyclesCounter = s.TimerCyclesCounter
+	e.ScanlineRenderCyclesCounter = s.ScanlineRenderCyclesCounter
+}
+
 func (e *Emulator) SaveState() {
 	s := NewState(e)
 	if _, err := os.Stat("./save.sav"); err == nil {
@@ -110,34 +143,5 @@ func (e *Emulator) LoadState() {
 	if err != nil {
 		panic(err)
 	}
-	e.AF = s.AF
-	e.BC = s.BC
-	e.DE = s.DE
-	e.HL = s.HL
-	e.SquareOne = s.SquareOne
-	e.SquareTwo = s.SquareTwo
-	e.Wave = s.Wave
-	e.Noise = s.Noise
-	e.RightVolume = s.RightVolume
-	e.LeftVolume = s.LeftVolume
-	e.RightChannelEnable = s.RightChannelEnable
-	e.LeftChannelEnable = s.LeftChannelEnable
-	e.SoundEnabled = s.SoundEnabled
-	e.SoundSampleCounter = s.SoundSampleCounter
-	e.SoundBuffer = s.SoundBuffer
-	e.ROM = s.ROM
-	e.RAM = s.RAM
-	e.ProgramCounter = s.ProgramCounter
-	e.StackPointer = s.StackPointer
-	e.CurrentROMBank = s.CurrentROMBank
-	e.CurrentRAMBank = s.CurrentRAMBank
-	e.EnableRAMBank = s.EnableRAMBank
-	e.EnableROMBank = s.EnableROMBank
-	e.Halted = s.Halted
-	e.DisableInterrupts = s.DisableInterrupts
-	e.PendingDisableInterrupts = s.PendingDisableInterrupts
-	e.PendingEnableInterrupts = s.PendingEnableInterrupts
-	e.DividerRegisterCyclesCounter = s.DividerRegisterCyclesCounter
-	e.TimerCyclesCounter = s.TimerCyclesCounter
-	e.ScanlineRenderCyclesCounter = s.ScanlineRenderCyclesCounter
+	e.CopyState(s)
 }

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func main() {
 	_, okLCDState := os.LookupEnv("NANA_LCD_STATE_DEBUG")
 	_, okMemoryAccess := os.LookupEnv("NANA_MEMORY_ACCESS_DEBUG")
 	_, okEnableTestPanics := os.LookupEnv("NANA_ENABLE_TEST_PANICS")
+	_, okEnableRewind := os.LookupEnv("NANA_ENABLE_REWIND")
 	maxCyclesEnv, okMaxCycles := os.LookupEnv("NANA_MAX_CYCLES")
 	maxCycles := 0
 	if okMaxCycles {
@@ -69,7 +70,7 @@ func main() {
 		}
 		maxCycles = maxCyclesInt
 	}
-	e = emulator.NewEmulator(okDebug, okLCDState, okMemoryAccess, okEnableTestPanics, maxCycles)
+	e = emulator.NewEmulator(okDebug, okLCDState, okMemoryAccess, okEnableTestPanics, okEnableRewind, maxCycles)
 	e.LoadCartridge(gameArg)
 	e.LoadState()
 


### PR DESCRIPTION
A very naive implementation of rewinding an emulation using the state saving implemented in https://github.com/Ruenzuo/nana/commit/27bce17c131d4d8195f7f380ba8034c9bcecff85.

Note: fast forward **is not a goal**. 

Pros: 

* All nondeterministic parts of the emulation are saved in the buffer.

Cons: 

* Very inefficient: a frame is 112K, given the 60FPS target the 2 minutes buffer runs about 800MB.

Alternatives:

* Compress frame data: `Emulator.ROM` can be compressed.
* Drop sound data.